### PR TITLE
Display or hide answer probability

### DIFF
--- a/.envexample
+++ b/.envexample
@@ -1,5 +1,6 @@
 VUE_APP_API_URL=https://myapi.com/
 VUE_APP_PUBLIC_PATH=/base_app_uri/
 VUE_APP_USE_FILTERS=false
+VUE_APP_DISPLAY_PROBABILITIES=true
 VUE_APP_DISPLAY_NAME=YOU
 VUE_APP_EXAMPLE_QUESTION=Quel est le coût d'un passeport ?

--- a/README.md
+++ b/README.md
@@ -50,5 +50,6 @@ Edit the `src/.env` file (you can find an example here `src/.envexample`)
 `VUE_APP_USE_FILTERS`: boolean for if you want to use filters or not. If you do want to use filters, you need to add a file describing your filters. it must follow this format : [filter file example](/filters.json)
 `VUE_APP_DISPLAY_NAME`: Name to be displayed in the title   
 `VUE_APP_EXAMPLE_QUESTION`: The question serving as example in the Homepage  
+`VUE_APP_DISPLAY_PROBABILITIES`: boolean for if you want to display the probability associated with the document
 
 ![search](/public/filters.png)

--- a/src/components/Answer.vue
+++ b/src/components/Answer.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="Number(answer.probability) > 0.20" class="mb-10">
     <div class="alignLeft paragraph w-11/12 max-w-screen-md mx-auto mt-8 p-2 text-left border-blue-400 border-2 rounded border-solid relative">
-      <p class="italic text-left rounded text-white px-2" style="width:fit-content" v-bind:class="bgColorTrust()">
+      <p class="italic text-left rounded text-white px-2" style="width:fit-content" v-bind:class="bgColorTrust()" v-if="displayProbability">
         Indice de confiance : {{ Number(answer.probability * 100).toLocaleString('fr',{maximumSignificantDigits:2}) }} %
       </p>
       <div ref="answ">
@@ -25,6 +25,9 @@ export default Vue.extend({
   props: [
     'answer',
   ],
+  data: () => ({
+    displayProbability: (process.env.VUE_APP_DISPLAY_PROBABILITIES ?? 'true') === 'true'
+  }),
   methods: {
     printAnswer(): void{
       const paragraph: any = this.$refs.answ

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -28,7 +28,7 @@ export default new Vuex.Store({
     async callInference({ commit, state, dispatch }) {
       const a = await callInferenceAsync(state.question, state.filters)
       if(a){
-        commit('setAnswers', a[0].answers)
+        commit('setAnswers', a.answers)
         return true
       }else{
         // eslint-disable-next-line


### PR DESCRIPTION
Related to https://github.com/etalab-ia/piaf_agent/issues/8

Result when the probabilities are hidden. I chose to kept the probability when it is too low: `Indice de confiance trop faible : 19 %. Nous ne pouvons afficher la réponse.` It does not make sense to just display `Nous ne pouvons afficher la réponse`.

I can hide the whole lines `Indice de confiance trop faible : 19 %. Nous ne pouvons afficher la réponse.` when we want to hide the probabilities

![2021-05-21_09-57-51_grim](https://user-images.githubusercontent.com/414642/119103054-04a90080-ba1b-11eb-943c-ead788850d3d.png)
