### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,46 @@
+name: Continuous integration
+on:
+  push:
+    tags-ignore: ['*']
+    branches:
+      - '*'
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+  build-test-lint:
+    name: ${{ matrix.action }}
+    needs: [deps]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        action: ['build', 'test', 'lint']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run ${{ matrix.action }}
+      - if: matrix.action == 'build'
+        uses: actions/upload-artifact@v2
+        with:
+          name: release
+          path: dist/


### PR DESCRIPTION
Adding github actions to automatically build and store the artifact.
Combined with #10 we could release a stateless artifact to simplify deployments and version management to the different clients.


We could even add custom job like on a git tag to create a release and automatically upload/attach the artifact to the release

![2021-05-21_15-47-51_grim](https://user-images.githubusercontent.com/414642/119151714-f1fcee80-ba4f-11eb-9114-263944feac91.png)

![2021-05-21_15-56-12_grim](https://user-images.githubusercontent.com/414642/119151727-f5907580-ba4f-11eb-8c9c-7f3d5c59de62.png)

![2021-05-21_15-55-07_grim](https://user-images.githubusercontent.com/414642/119151736-f7f2cf80-ba4f-11eb-80cd-03eef438bb36.png)
